### PR TITLE
fix(aid, create): fix double hash for afs mnemonic and resolve afs owner remotely

### DIFF
--- a/add.js
+++ b/add.js
@@ -116,7 +116,7 @@ async function add({
     reader.setMaxListeners(0)
     writer.setMaxListeners(0)
     await createPipe({ reader, writer, stats })
-    debug("Successfully added file", path)
+    debug('Successfully added file', path)
   }
 
   async function createPipe({ reader, writer, stats }) {

--- a/aid.js
+++ b/aid.js
@@ -1,6 +1,5 @@
 const debug = require('debug')('ara-filesystem:aid')
 const aid = require('ara-identity')
-const crypto = require('ara-crypto')
 const context = require('ara-context')()
 const { kEd25519VerificationKey2018 } = require('ld-cryptosuite-registry')
 
@@ -27,7 +26,6 @@ async function create(seed, publicKey) {
 
   publicKey += kOwnerSuffix
 
-  const password = crypto.blake2b(Buffer.from(seed)).toString()
   let identity
   try {
     const did = {
@@ -37,7 +35,7 @@ async function create(seed, publicKey) {
         authenticationKey: publicKey
       }
     }
-    identity = await aid.create({ context, password, did })
+    identity = await aid.create({ context, password: seed, did })
   } catch (err) { debug(err.stack || err) }
   return identity
 }

--- a/commit.js
+++ b/commit.js
@@ -153,7 +153,9 @@ async function estimateCommitGasCost({
         const data = `0x${buffers[offset]}`
 
         const lastWrite = contentsLength - 1 === i && buffersLength - 1 === j
-        cost += await deployed.methods.write(hIdentity, index, offset, data, lastWrite).estimateGas({ gas: 500000 })
+        cost += await deployed.methods
+          .write(hIdentity, index, offset, data, lastWrite)
+          .estimateGas({ gas: 500000 })
       }
     }
   } catch (err) {

--- a/create.js
+++ b/create.js
@@ -74,7 +74,9 @@ async function create({
     afs.ddo = afsDdo
   } else if (owner) {
     owner = validateDid(owner)
-    const ddo = await aid.resolve(owner)
+    let keystore = await loadSecrets(kResolverKey)
+    const ddo = await aid.resolve(owner, { key: kResolverKey, keystore })
+
     if (null === ddo || 'object' !== typeof ddo) {
       throw new TypeError('ara-filesystem.create: Unable to resolve owner DID')
     }
@@ -88,7 +90,7 @@ async function create({
 
     await writeIdentity(afsId)
 
-    let keystore = await loadSecrets(kArchiverKey)
+    keystore = await loadSecrets(kArchiverKey)
     await aid.archive(afsId, { key: kArchiverKey, keystore })
 
     const { publicKey, secretKey } = afsId

--- a/price.js
+++ b/price.js
@@ -28,7 +28,9 @@ async function estimateSetPriceGasCost({
   try {
     const hIdentity = hashIdentity(did)
     const deployed = getDeployedContract(abi, kPriceAddress)
-    cost = await deployed.methods.setPrice(hIdentity, price, kStorageAddress).estimateGas({ gas: 500000 })
+    cost = await deployed.methods
+      .setPrice(hIdentity, price, kStorageAddress)
+      .estimateGas({ gas: 500000 })
   } catch (err) {
     throw new Error(`This AFS has not been committed to the network, 
       please commit before trying to set a price.`)

--- a/util.js
+++ b/util.js
@@ -1,6 +1,5 @@
 const { secrets } = require('ara-network')
 const { create } = require('ara-identity/did')
-const { resolve } = require('./aid')
 const { web3 } = require('ara-context')()
 const aid = require('./aid')
 
@@ -159,7 +158,7 @@ async function getAfsId(did, mnemonic) {
   const keystore = await loadSecrets(kResolverKey)
   const afsDdo = await aid.resolve(did, { key: kResolverKey, keystore })
   const owner = getDocumentOwner(afsDdo)
-  return await aid.create(mnemonic, owner)
+  return aid.create(mnemonic, owner)
 }
 
 module.exports = {


### PR DESCRIPTION
## Fixes

  - Hash AFS mnemonic before passing into `ara-identity` (where it is hashed again)
  - Resolve AFS owner identity locally only when creating AFS
  - Lint errors