### PR TITLE
Update encrypt/decrypt functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ara-crypto": "github:arablocks/ara-crypto",
     "ara-network": "github:arablocks/ara-network",
     "ara-runtime-configuration": "github:arablocks/ara-runtime-configuration",
+    "ara-secret-storage": "github:arablocks/ara-secret-storage",
     "ara-util": "github:arablocks/ara-util",
     "ara-web3": "github:arablocks/ara-web3",
     "cfsnet": "github:arablocks/cfsnet",

--- a/util.js
+++ b/util.js
@@ -1,8 +1,8 @@
+const ss = require('ara-secret-storage')
+
 const {
   blake2b,
   keyPair,
-  encrypt: cryptoEncrypt,
-  decrypt: cryptoDecrypt,
   randomBytes: cryptoRandomBytes
 } = require('ara-crypto')
 
@@ -13,12 +13,12 @@ function generateKeypair(password) {
 }
 
 function encrypt(value, opts) {
-  return cryptoEncrypt(value, opts)
+  return ss.encrypt(value, opts)
 }
 
 function decrypt(value, opts) {
   const keystore = JSON.parse(value.keystore)
-  return cryptoDecrypt(keystore, opts)
+  return ss.decrypt(keystore, opts)
 }
 
 function randomBytes(size) {


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Deprecates use of `ara-crypto.encrypt` and `ara-crypto.decrypt`, and instead uses `ara-secret-storage`