### PR TITLE
fix(): Fix issue with arcv + resv keys

### DIFF
--- a/bin/ara-filesystem
+++ b/bin/ara-filesystem
@@ -16,6 +16,7 @@ const ProgressBar = require('progress')
 const bytes = require('pretty-bytes')
 const table = require('table')
 const prettyjson = require('prettyjson')
+const rc = require('../rc')()
 
 const isDirectory = require('is-directory')
 const isFile = require('is-file')
@@ -55,20 +56,35 @@ const { argv } = program
         type: 'string',
         describe: "This AFS owner's ARA decentralized identity (did) URI"
       })
-      .option('secret', {
+      .option('archiverSecret', {
         alias: 's',
         type: 'string',
-        describe: 'key filename. Default: kArchiverSecret in constants.js',
+        describe: 'Secret for the `archiver` key',
+        required: true
       })
-      .option('name', {
+      .option('archiverName', {
         alias: 'n',
         type: 'string',
-        describe: 'Keyring name. Default: kArchiverRemote in constants.js',
+        describe: 'Name of `archiver` key in keyring',
+        default: 'archiver'
+      })
+      .option('resolverSecret', {
+        alias: 's',
+        type: 'string',
+        describe: 'Secret for the `resolver` key',
+        required: true
+      })
+      .option('resolverName', {
+        alias: 'n',
+        type: 'string',
+        describe: 'Name of `resolver` key in keyring',
+        default: 'resolver'
       })
       .option('keyring', {
         alias: 'k',
         type: 'string',
-        describe: 'Keyring path. Default: kSecretsDir = \'secret\' in rc.js',
+        describe: 'Keyring path.',
+        default: rc.network.identity.keyring + ".pub"
       })
   }, oncreate)
   .command('add <did> <pathspec...>', "Add files or directories to an AFS", (program) => {
@@ -257,14 +273,24 @@ async function oncreate(argv) {
     owner = 'did:ara:' + owner
   }
 
-  const { secret, name, keyring } = argv
-  const opts = { secret, name, keyring }
+  const keyringOpts = {
+    archiver: {
+      secret: argv.archiverSecret,
+      name: argv.archiverName,
+      keyring: argv.keyring
+    },
+    resolver: {
+      secret: argv.resolverSecret,
+      name: argv.resolverName,
+      keyring: argv.keyring
+    },
+  }
 
   const { password } = await promptForPassword()
 
   let arafs
   try {
-    arafs = await afs.create({ owner, password, opts })
+    arafs = await afs.create({ owner, password, keyringOpts })
   } catch (err) { onfatal(err) }
 
   info('New AFS created with DID: \n\n\t\t\t< %s >\n', arafs.afs.did)

--- a/create.js
+++ b/create.js
@@ -102,9 +102,9 @@ async function create({
       ({ mnemonic } = afsId)
 
       await writeIdentity(afsId)
-      await aid.archive(afsId, keyringOpts)
+      await aid.archive(afsId, keyringOpts && keyringOpts.archiver)
 
-      afsDdo = await aid.resolve(toHex(afsId.publicKey))
+      afsDdo = await aid.resolve(toHex(afsId.publicKey), keyringOpts && keyringOpts.resolver)
       if (null == afsDdo || 'object' !== typeof afsDdo) {
         throw new TypeError('AFS identity not successfully resolved.')
       }


### PR DESCRIPTION
Fixes issue with `afs create` not having defaults and it being super easy to run into a hard-to-trace error. 