### PR TITLE
chore(package.json): removed ara-web3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ara-runtime-configuration": "github:arablocks/ara-runtime-configuration",
     "ara-secret-storage": "github:arablocks/ara-secret-storage",
     "ara-util": "github:arablocks/ara-util",
-    "ara-web3": "github:arablocks/ara-web3",
     "cfsnet": "github:arablocks/cfsnet",
     "cli-width": "^2.2.0",
     "debug": "^3.1.0",


### PR DESCRIPTION
Not listed as a dependency in develop, but it is in master. Breaking modules like contracts, util, if trying to fresh install.
