### PR TITLE
chore(package.json): Bump `ara-identity` to release 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ara-context": "github:arablocks/ara-context",
     "ara-contracts": "github:arablocks/ara-contracts#0.2.5",
     "ara-crypto": "github:arablocks/ara-crypto",
-    "ara-identity": "github:arablocks/ara-identity#0.15.1",
+    "ara-identity": "github:arablocks/ara-identity#0.22.0",
     "ara-network": "github:arablocks/ara-network",
     "ara-runtime-configuration": "github:arablocks/ara-runtime-configuration",
     "ara-secret-storage": "github:arablocks/ara-secret-storage",


### PR DESCRIPTION
Fixes # CLI failing to create `afs` (by failing to archive) when using `ara-network-node-identity-archiver#0.36.0`

## Proposed Changes

  - Use latest `ara-identity`
  - Works with `ara-network-node-identity-archiver#0.36.0`