### PR TITLE
refactor():metadata.readFile

### DIFF
--- a/bin/ara-filesystem
+++ b/bin/ara-filesystem
@@ -77,7 +77,7 @@ const { argv } = program
       .option('keyring', {
         alias: 'k',
         type: 'string',
-        default: rc.network.identity.keyring + ".pub",
+        default: rc.network.identity.keyring ,
         describe: 'Path to the keyring',
       })
   }, oncreate)

--- a/metadata.js
+++ b/metadata.js
@@ -166,7 +166,8 @@ async function readFile(opts) {
   try {
     file = await cfs.readFile(kMetadataFile)
   } catch (err) {
-    throw new Error('Metadata file doesn\'t exist.')
+    debug('No metadata for %s', did)
+    return null
   }
   return JSON.parse(file.toString())
 }


### PR DESCRIPTION
-If no metadata, returns null instead of throwing
-Removed "+ '.pub' " from afs bin. Was causing it to pass in secret.pub.pub