### PR TITLE
fix(create.js): keyringOpts extend

### DIFF
--- a/create.js
+++ b/create.js
@@ -74,7 +74,7 @@ async function create(opts) {
     storage
   } = opts
 
-  keyringOpts = extend(true, {
+  keyringOpts = extend(true, keyringOpts, {
     archiver: {
       network: (keyringOpts.archiver && keyringOpts.archiver.network) || keyringOpts.network,
       secret: (keyringOpts.archiver && keyringOpts.archiver.secret) || keyringOpts.secret,
@@ -85,7 +85,7 @@ async function create(opts) {
       secret: (keyringOpts.resolver && keyringOpts.resolver.secret) || keyringOpts.secret,
       keyring: (keyringOpts.resolver && keyringOpts.resolver.keyring) || keyringOpts.keyring
     }
-  }, keyringOpts)
+  })
 
   let afs
   let mnemonic


### PR DESCRIPTION
Fixes # `archiver|resolver` object overwritten with `archiver|resolver` string

## Proposed Changes

  - reverse extend order of keyringOpts object
```
keyringOpts { secret: 'sec',
  archiver: 
   { secret: 'sec',
     keyring: '/root/.ara/keyrings/key.pub' },
  resolver: 
   { secret: 'sec',
     keyring: '/root/.ara/keyrings/key.pub' },
  keyring: '/root/.ara/keyrings/key.pub' }
```
  instead of
```
keyringOpts { archiver: 'archiver',
  resolver: 'resolver',
  secret: 'sec',
  keyring: '/root/.ara/keyrings/key.pub' }
```