### PR TITLE
0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.4.2](https://github.com/AraBlocks/ara-filesystem/compare/0.2.13...0.4.2) (2018-11-07)
+## [0.4.3](https://github.com/AraBlocks/ara-filesystem/compare/0.2.13...0.4.3) (2018-11-07)
 
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ara-filesystem",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "The Ara FileSystem, isolated and secure file systems backed by Ara identities.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
0.4.2 was never released through `npm version patch` but the tag already existed so had to run `npm version 0.4.3`